### PR TITLE
Bulk PUT is not efficient

### DIFF
--- a/HSDS/Common/Application.h
+++ b/HSDS/Common/Application.h
@@ -167,6 +167,12 @@ public:
     DDS::ReturnCode_t retcode = DDS::RETCODE_OK;
     Unit<T>& unit = this->unit<T>();
 
+    const auto pos = unit.container.find(element);
+    if (pos != unit.container.end() && *pos == element) {
+      // No change.
+      return retcode;
+    }
+
     // Save.
     unit.container.insert(element);
 

--- a/HSDS/Common/Container.h
+++ b/HSDS/Common/Container.h
@@ -15,6 +15,7 @@ public:
   typedef std::pair<std::string, std::string> KeyType;
   typedef std::map<KeyType, size_t> MapType;
   typedef typename ListType::const_iterator const_iterator;
+  typedef typename MapType::const_iterator const_ordered_iterator;
 
   const_iterator find(const KeyType& key) const
   {
@@ -28,8 +29,20 @@ public:
     return pos2;
   }
 
+  const_iterator find(const T& value) const
+  {
+    return find(KeyType(value.dpmgid(), value.id()));
+  }
+
   const_iterator begin() const { return list_.begin(); }
   const_iterator end() const { return list_.end(); }
+  const_ordered_iterator ordered_begin() const { return map_.begin(); }
+  const_ordered_iterator ordered_end() const { return map_.end(); }
+
+  const T& at(size_t idx) const
+  {
+    return list_.at(idx);
+  }
 
   void insert(const T& value)
   {

--- a/HSDS/Common/HSDSCommon.mpc
+++ b/HSDS/Common/HSDSCommon.mpc
@@ -4,7 +4,7 @@ project: opendds_cxx11, dcps_rtps_udp, CommunitySecurityPlugin, install {
   lit_libs += curl
   lit_libs += curlcpp
   idlflags += -Wb,export_include=HSDS_Common_export.h -Wb,export_macro=HSDS_Common_Export -SS
-  dcps_ts_flags += -Gxtypes-complete -Wb,export_include=HSDS_Common_export.h -Wb,export_macro=HSDS_Common_Export
+  dcps_ts_flags += -Gxtypes-complete -Gequality -Wb,export_include=HSDS_Common_export.h -Wb,export_macro=HSDS_Common_Export
 
   TypeSupport_Files {
     HSDS3.idl


### PR DESCRIPTION
Problem
-------

The bulk PUT operation unregisters all of the existing data before writing the new data.  It is envisioned that very few of the instances will change so it would be more efficient to only write those that are new or have changed and only unregister those that need to be unregistered.

Solution
--------

Compare the new samples to the existing samples and perform the necessary operation.

Note
----

This can't be merged until OpenDDS generates `==` for the C++11 mapping.