### PR TITLE
Container insert always adds to the list

### DIFF
--- a/HSDS/Common/Container.h
+++ b/HSDS/Common/Container.h
@@ -37,10 +37,10 @@ public:
     MapType::const_iterator pos = map_.find(key);
     if (pos != map_.end()) {
       list_[pos->second] = value;
+    } else {
+      map_[key] = list_.size();
+      list_.push_back(value);
     }
-
-    map_[key] = list_.size();
-    list_.push_back(value);
   }
 
   void erase(const T& value)


### PR DESCRIPTION
Problem
-------

Inserting into the container always adds to the list.  This introduces inconsistency between the map and the list which causes multiple results to be return, bulk delete to fail, and other problems.

Solution
--------

Only add to the list if a new key is inserted.