### PR TITLE
Stats API doesn't expose DDS discovered entity counts

### DIFF
--- a/HSDS/Common/Application.cpp
+++ b/HSDS/Common/Application.cpp
@@ -692,3 +692,42 @@ template<> Unit<HSDS3::ServiceArea>& Application::unit<HSDS3::ServiceArea>() { r
 template<> Unit<HSDS3::ServiceAtLocation>& Application::unit<HSDS3::ServiceAtLocation>() { return service_at_location_; }
 template<> Unit<HSDS3::Taxonomy>& Application::unit<HSDS3::Taxonomy>() { return taxonomy_; }
 template<> Unit<HSDS3::TaxonomyTerm>& Application::unit<HSDS3::TaxonomyTerm>() { return taxonomy_term_; }
+
+template <>
+DDS::DataReader_var Application::reader<DDS::ParticipantBuiltinTopicData>() const
+{
+  DDS::Subscriber_var bit_subscriber = participant_->get_builtin_subscriber();
+  return bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_PARTICIPANT_TOPIC);
+}
+
+template <>
+DDS::DataReader_var Application::reader<DDS::PublicationBuiltinTopicData>() const
+{
+  DDS::Subscriber_var bit_subscriber = participant_->get_builtin_subscriber();
+  return bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_PUBLICATION_TOPIC);
+}
+
+template <>
+DDS::DataReader_var Application::reader<DDS::SubscriptionBuiltinTopicData>() const
+{
+  DDS::Subscriber_var bit_subscriber = participant_->get_builtin_subscriber();
+  return bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_SUBSCRIPTION_TOPIC);
+}
+
+template <>
+void Application::set_count<DDS::ParticipantBuiltinTopicData>(size_t count)
+{
+  participant_count_ = count;
+}
+
+template <>
+void Application::set_count<DDS::PublicationBuiltinTopicData>(size_t count)
+{
+  publication_count_ = count;
+}
+
+template <>
+void Application::set_count<DDS::SubscriptionBuiltinTopicData>(size_t count)
+{
+  subscription_count_ = count;
+}

--- a/HSDS/Common/Application.h
+++ b/HSDS/Common/Application.h
@@ -63,6 +63,9 @@ public:
     , service_at_location_("SERVICE_AT_LOCATION_TOPIC", HSDS3::SERVICE_AT_LOCATION_ENDPOINT, HSDS3::SERVICE_AT_LOCATION_JSON_FILE)
     , taxonomy_("TAXONOMY_TOPIC", HSDS3::TAXONOMY_ENDPOINT, HSDS3::TAXONOMY_JSON_FILE)
     , taxonomy_term_("TAXONOMY_TERM_TOPIC", HSDS3::TAXONOMY_TERM_ENDPOINT, HSDS3::TAXONOMY_TERM_JSON_FILE)
+    , participant_count_(0)
+    , publication_count_(0)
+    , subscription_count_(0)
   {
     server_poll_period_.sec = 300;
     server_poll_period_.nanosec = 0;
@@ -433,6 +436,16 @@ public:
 
   ACE_Thread_Mutex& get_mutex() { return mutex_; }
 
+  template <typename T>
+  DDS::DataReader_var reader() const;
+
+  template <typename T>
+  void set_count(size_t count);
+
+  size_t participant_count() const { return participant_count_; }
+  size_t publication_count() const { return publication_count_; }
+  size_t subscription_count() const { return subscription_count_; }
+
  private:
   std::string dpm_url_;
   std::string dpm_gid_;
@@ -494,6 +507,10 @@ public:
   Unit<HSDS3::ServiceAtLocation> service_at_location_;
   Unit<HSDS3::Taxonomy> taxonomy_;
   Unit<HSDS3::TaxonomyTerm> taxonomy_term_;
+
+  size_t participant_count_;
+  size_t publication_count_;
+  size_t subscription_count_;
 };
 
 // template <>

--- a/HSDS/Reader/Stats.h
+++ b/HSDS/Reader/Stats.h
@@ -46,12 +46,12 @@ public:
     return convert_to_vector();
   }
 
-  void collect_datapoint()
+  void collect_datapoint(const OpenDDS::DCPS::SystemTimePoint& now)
   {
     DataPoint dp;
     {
       ACE_GUARD(ACE_Thread_Mutex, g, application_.get_mutex());
-      dp.timestamp = OpenDDS::DCPS::SystemTimePoint::now();
+      dp.timestamp = now;
       const Unit<T>& unit = application_.unit<T>();
       dp.record_count = unit.container.size();
 

--- a/HSDS/Reader/StatsApplication.cpp
+++ b/HSDS/Reader/StatsApplication.cpp
@@ -32,9 +32,10 @@ void StatsApplication::run()
 
 void StatsApplication::collect_datapoints()
 {
-  organization_stats_.collect_datapoint();
-  location_stats_.collect_datapoint();
-  service_stats_.collect_datapoint();
+  const OpenDDS::DCPS::SystemTimePoint now = OpenDDS::DCPS::SystemTimePoint::now();
+  organization_stats_.collect_datapoint(now);
+  location_stats_.collect_datapoint(now);
+  service_stats_.collect_datapoint(now);
 }
 
 template<> Stats<HSDS3::Organization>& StatsApplication::get_stats<HSDS3::Organization>()

--- a/HSDS/Reader/StatsApplication.h
+++ b/HSDS/Reader/StatsApplication.h
@@ -19,6 +19,8 @@ public:
 
   const Application& application() const { return application_; }
 
+  Application& application() { return application_; }
+
 private:
   void collect_datapoints();
 


### PR DESCRIPTION
Problem
-------

The Stats API doesn't expose the number of discovered participants, publications, and subscriptions.

Solution
--------

Implement an endpoint `/dds/statistics` that exposes these counts as follows:

          {"participants":3,"publications":21,"subscriptions":21}