### PR TITLE
Schedule bymonthday and byyearday should be strings

### DIFF
--- a/HSDS/Common/HSDS3.idl
+++ b/HSDS/Common/HSDS3.idl
@@ -233,8 +233,8 @@ module HSDS3 {
     long interval;
     string byday;
     string byweekno;
-    long bymonthday;
-    long byyearday;
+    string bymonthday;
+    string byyearday;
     string description;
     string opens_at; // Time?
     string closes_at; // Time?


### PR DESCRIPTION
Problem
-------

According to the spec, bymonthday and byyearday should be strings.

Solution
--------

Make them strings.